### PR TITLE
SELinux policy for Tailscale SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SELinux policy for Tailscale
 
 # Supported features
 1. Service Start and Stop
-2. Tailscale SSH
+2. Tailscale SSH for unconfined users only
 
 # Steps to build
 ## Pre-requisites

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ sudo restorecon -R /var/lib/tailscale
 sudo restorecon -R /var/run/tailscale
 ```
 This is required only once, until Tailscale is reinstalled
+
 NOTE: Ignore restorecon error, if it fails to find "/var/run/tailscale"
 
 ## 4 - Start Tailscale and check the context again

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This will create the policy file "tailscaled.pp"
 Environment tested on
 - Tailscale 1.34.2
 - Fedora 37
-- Kernel ?
+- Kernel 6.1.6-200.fc37.x86_64
 
 ## 1 - Check context of an unconfined Tailscale service
 ```shell
@@ -95,3 +95,7 @@ sudo restorecon -R /var/run/tailscale
 NOTE: Ignore restorecon error, if it fails to find "/var/run/tailscale"
 
 4. Start tailscale service 
+
+# Troubleshooting
+
+Ref - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux/troubleshooting-problems-related-to-selinux_using-selinux

--- a/README.md
+++ b/README.md
@@ -1,2 +1,97 @@
 # tailscale-selinux-policy
 SELinux policy for Tailscale
+
+# Supported environment
+1. Fedora 37
+
+# Supported features
+1. Service Start and Stop
+2. Tailscale SSH
+
+# Steps to build
+## Pre-requisites
+```shell
+dnf install selinux-policy-devel
+```
+
+## Clone the policy source
+```shell
+git clone git@github.com:abhiseksanyal/tailscale-selinux-policy.git
+cd tailscale-selinux-policy
+make -f /usr/share/selinux/devel/Makefile tailscaled.pp
+```
+This will create the policy file "tailscaled.pp"
+
+# Steps to test
+
+Environment tested on
+- Tailscale 1.34.2
+- Fedora 37
+- Kernel ?
+
+## 1 - Check context of an unconfined Tailscale service
+```shell
+ps -q $(pidof tailscaled) -o pid,label,comm
+```
+Output will be something like
+```text
+    PID LABEL                                     COMMAND
+ 221929 system_u:system_r:unconfined_service_t:s0 tailscaled
+```
+NOTE: You can also run something like  ```ps -eafZ```
+
+Stop tailscale service
+```shell
+sudo systemctl stop tailscaled
+```
+
+## 2 - Load the SELinux policy
+```shell
+sudo semodule -i tailscaled.pp
+```
+
+## 3 - Set the context for Tailscale files
+```shell
+sudo restorecon /usr/sbin/tailscaled
+sudo restorecon /lib/systemd/system/tailscaled.service
+sudo restorecon -R /var/lib/tailscale
+sudo restorecon -R /var/run/tailscale
+```
+This is required only once, until Tailscale is reinstalled
+NOTE: Ignore restorecon error, if it fails to find "/var/run/tailscale"
+
+## 4 - Start Tailscale and check the context again
+Start tailscale service
+```shell
+sudo systemctl start tailscaled
+```
+
+Check the context
+```shell
+ps -q $(pidof tailscaled) -o pid,label,comm
+```
+Output will be something like
+```text
+    PID LABEL                             COMMAND
+ 222705 system_u:system_r:tailscaled_t:s0 tailscaled
+```
+NOTE: You can also run something like  ```ps -eafZ```
+
+Tailscale service is now running as a confined service with a context of "tailscaled_t"
+
+# Steps to revert and unload the SELinux policy
+1. Stop tailscale service
+2. Unload the SELinux policy using the following command
+```shell
+sudo semodule -r tailscaled
+```
+3. Restore the context for Tailscale files
+```shell
+sudo restorecon /usr/sbin/tailscaled
+sudo restorecon /lib/systemd/system/tailscaled.service
+sudo restorecon -R /var/lib/tailscale
+sudo restorecon -R /var/run/tailscale
+```
+NOTE: Ignore restorecon error, if it fails to find "/var/run/tailscale"
+
+4. Start tailscale service 

--- a/tailscaled.fc
+++ b/tailscaled.fc
@@ -15,6 +15,7 @@
 /usr/sbin/tailscaled					--  gen_context(system_u:object_r:tailscaled_exec_t, s0)
 /lib/systemd/system/tailscaled.service	--	gen_context(system_u:object_r:tailscaled_unit_file_t, s0)
 /var/lib/tailscale(/.*)?					gen_context(system_u:object_r:tailscale_var_lib_t, s0)
+/var/run/tailscale(/.*)?					gen_context(system_u:object_r:tailscale_var_run_t, s0)
 
 # TODO: Security Context for following files have not been generated
 # /etc/default/tailscaled

--- a/tailscaled.fc
+++ b/tailscaled.fc
@@ -1,0 +1,21 @@
+# This is the Tailscale File Context (fc) file
+#
+# There are three fields in this file.
+# - The first is a regular expression used to map files/directories to file context.
+# - The second optional field is a file type field. If it does not exist, it indicates match all. 
+#   If it does exist it must be a dash '-' followed by the file type. A regular file would be --,
+#   a directory would be -d, a chr_file would be -c
+# - The third field is a specification of the files security context to be assigned which is done using
+#   the gen_context macro
+#
+# References,
+# - https://selinuxproject.org/page/NB_RefPolicy#gen_context_Macro
+# - https://danwalsh.livejournal.com/8707.html
+
+/usr/sbin/tailscaled					--  gen_context(system_u:object_r:tailscaled_exec_t, s0)
+/lib/systemd/system/tailscaled.service	--	gen_context(system_u:object_r:tailscaled_unit_file_t, s0)
+
+# TODO: Security Context for following files have not been generated
+# /etc/default/tailscaled
+# /usr/bin/tailscale
+# /var/cache/tailscale

--- a/tailscaled.fc
+++ b/tailscaled.fc
@@ -14,6 +14,7 @@
 
 /usr/sbin/tailscaled					--  gen_context(system_u:object_r:tailscaled_exec_t, s0)
 /lib/systemd/system/tailscaled.service	--	gen_context(system_u:object_r:tailscaled_unit_file_t, s0)
+/var/lib/tailscale(/.*)?					gen_context(system_u:object_r:tailscale_var_lib_t, s0)
 
 # TODO: Security Context for following files have not been generated
 # /etc/default/tailscaled

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -19,17 +19,14 @@ interface(`tailscale_network_connection',`
 			type node_t;
 		')
 		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
-		allow $1 chkpwd_t:process { noatsecure };
 
 		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
-        allow $1 self:tcp_socket create_stream_socket_perms;
-        allow $1 self:udp_socket create_socket_perms;
+
+		allow $1 self:rawip_socket { setopt create bind };
+
 		allow $1 node_t:udp_socket node_bind;
 		allow $1 node_t:tcp_socket node_bind;
-		allow $1 self:unix_dgram_socket { create connect getattr write };
 		allow $1 http_port_t:tcp_socket name_connect;
 		allow $1 kernel_t:unix_dgram_socket sendto;
-		allow $1 self:netlink_route_socket { create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write };
-		allow $1 self:netlink_generic_socket { read bind create getattr setopt write };
-		allow $1 self:rawip_socket { setopt create bind };
+		allow $1 chkpwd_t:process { noatsecure };
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -14,8 +14,9 @@
 interface(`tailscale_network_connection',`
 		gen_require(`
 			type http_port_t, net_conf_t;
-			type proc_t, proc_net_t;
-			type sysctl_net_t;
+#			type proc_t;
+			type proc_net_t;
+#			type sysctl_net_t;
 			type sysfs_t;
 			type system_dbusd_var_run_t, system_dbusd_t;
 			type var_lib_t;
@@ -23,7 +24,7 @@ interface(`tailscale_network_connection',`
 			# type passwd_file_t;
 			class dbus { send_msg };
 			type NetworkManager_t;
-			type cert_t;
+#			type cert_t;
 			type kernel_t;
 			type tun_tap_device_t;
 			type kmod_exec_t;
@@ -51,9 +52,9 @@ interface(`tailscale_network_connection',`
 		#allow $1 iptables_exec_t:file { getattr execute };
 		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
 		allow $1 NetworkManager_t:dbus send_msg;
-		allow $1 cert_t:dir { search read open };
-		allow $1 cert_t:file { read open getattr };
-		allow $1 cert_t:lnk_file read;
+#		allow $1 cert_t:dir { search read open };
+#		allow $1 cert_t:file { read open getattr };
+#		allow $1 cert_t:lnk_file read;
 		# allow $1 passwd_file_t:file { read open getattr };
         allow $1 self:tcp_socket create_stream_socket_perms;
         allow $1 self:udp_socket create_socket_perms;
@@ -66,8 +67,8 @@ interface(`tailscale_network_connection',`
 		allow $1 net_conf_t:lnk_file read;
 		allow $1 proc_net_t:lnk_file read;
 		allow $1 proc_net_t:file { read open getattr };
-		allow $1 proc_t:file { read open };
-		allow $1 proc_t:dir read;
+#		allow $1 proc_t:file { read open };
+#		allow $1 proc_t:dir read;
 		allow $1 self:netlink_route_socket { create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write };
 		allow $1 self:netlink_generic_socket { read bind create getattr setopt write };
 		allow $1 self:rawip_socket { setopt create bind };
@@ -85,8 +86,8 @@ interface(`tailscale_network_connection',`
 		allow $1 modules_dep_t:file { read open getattr map };
 		# allow $1 self:netlink_route_socket { create bind getattr setopt read write nlmsg_read nlmsg_write };
 # create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write
-		allow $1 sysctl_net_t:dir { search getattr };
-		allow $1 sysctl_net_t:file { read open getattr };
+#		allow $1 sysctl_net_t:dir { search getattr };
+#		allow $1 sysctl_net_t:file { read open getattr };
 		allow $1 sysfs_t:file { read open getattr };
 		allow $1 sysfs_t:lnk_file read;
 		allow $1 system_dbusd_var_run_t:dir search;

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -1,27 +1,40 @@
-## <summary>Policy for network configuration: tailscale server and client.</summary>
-#
+
+## <summary>policy for tailscaled</summary>
+
 ########################################
 ## <summary>
-##      Perform network connections.
+##	Execute tailscaled_exec_t in the tailscaled domain.
 ## </summary>
 ## <param name="domain">
-##      <summary>
-##      Domain allowed access.
-##      </summary>
+## <summary>
+##	Domain allowed to transition.
+## </summary>
 ## </param>
-## <rolecap/>
 #
-interface(`tailscale_network_connection',`
-		#gen_require(`
-		#	type kernel_t;
+interface(`tailscaled_domtrans',`
+	gen_require(`
+		type tailscaled_t, tailscaled_exec_t;
+	')
 
-		#')
-		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
+	corecmd_search_bin($1)
+	domtrans_pattern($1, tailscaled_exec_t, tailscaled_t)
+')
 
-		# allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
+######################################
+## <summary>
+##	Execute tailscaled in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`tailscaled_exec',`
+	gen_require(`
+		type tailscaled_exec_t;
+	')
 
-		#allow $1 self:rawip_socket { setopt create bind };
-
-		#allow $1 kernel_t:unix_dgram_socket sendto;
-		#allow $1 chkpwd_t:process { noatsecure };
+	corecmd_search_bin($1)
+	can_exec($1, tailscaled_exec_t)
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -14,55 +14,18 @@
 interface(`tailscale_network_connection',`
 		gen_require(`
 			type http_port_t, net_conf_t;
-#			type proc_t;
-#			type proc_net_t;
-#			type sysctl_net_t;
-#			type sysfs_t;
-#
-#			type system_dbusd_var_run_t;
-
-#			type system_dbusd_t;
-#
-#			type var_lib_t;
-
-#			type var_run_t;
-
-			# type passwd_file_t;
-#			class dbus { send_msg };
-#			type NetworkManager_t;
-#			type cert_t;
 			type kernel_t;
 			type tun_tap_device_t;
-#			type kmod_exec_t;
 
-#			type modules_dep_t, modules_conf_t, modules_object_t;
 			type init_t, init_var_run_t;
-			#type iptables_exec_t;
 			type node_t;
-#			type sshd_key_t;
-			# type devpts_t;
-		#	type local_login_t;
-#			type user_home_dir_t;
 		')
-#		allow $1 user_home_dir_t:dir getattr;
-# userdom_getattr_user_home_dirs(
-		# domtrans_pattern($1, login_exec_t, login_t);
-
-		# allow $1 devpts_t:chr_file { open read write ioctl getattr setattr relabelfrom relabelto };
-
-		#allow $1 local_login_t:process { noatsecure rlimitinh };
 		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
 		allow $1 chkpwd_t:process { noatsecure };
 
 		allow $1 init_t:dir search;
 		allow $1 init_t:file { read open getattr };
-		#allow $1 iptables_exec_t:file { getattr execute };
 		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
-#		allow $1 NetworkManager_t:dbus send_msg;
-#		allow $1 cert_t:dir { search read open };
-#		allow $1 cert_t:file { read open getattr };
-#		allow $1 cert_t:lnk_file read;
-		# allow $1 passwd_file_t:file { read open getattr };
         allow $1 self:tcp_socket create_stream_socket_perms;
         allow $1 self:udp_socket create_socket_perms;
 		allow $1 node_t:udp_socket node_bind;
@@ -72,10 +35,6 @@ interface(`tailscale_network_connection',`
 		allow $1 kernel_t:unix_dgram_socket sendto;
 		allow $1 net_conf_t:file { getattr read open };
 		allow $1 net_conf_t:lnk_file read;
-#		allow $1 proc_net_t:lnk_file read;
-#		allow $1 proc_net_t:file { read open getattr };
-#		allow $1 proc_t:file { read open };
-#		allow $1 proc_t:dir read;
 		allow $1 self:netlink_route_socket { create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write };
 		allow $1 self:netlink_generic_socket { read bind create getattr setopt write };
 		allow $1 self:rawip_socket { setopt create bind };
@@ -83,32 +42,4 @@ interface(`tailscale_network_connection',`
 		allow $1 tun_tap_device_t:chr_file { all_chr_file_perms };
 		allow $1 self:tun_socket create;
 		allow $1 init_var_run_t:unix_dgram_socket { sendto write };
-		# allow $1 init_var_run_t:sock_file { all_sock_file_perms };
-		# allow $1 tun_tap_device_t:chr_file { read write open ioctl getattr create };
-		# dev_filetrans($1, tun_tap_device_t, chr_file, "tailscale0")
-#		allow $1 kmod_exec_t:file { open read execute execute_no_trans map };
-
-#		allow $1 modules_conf_t:dir { getattr read open search };
-#		allow $1 modules_conf_t:file { getattr read open };
-#		allow $1 modules_object_t:dir { search read open };
-#		allow $1 modules_dep_t:file { read open getattr map };
-#
-		# allow $1 self:netlink_route_socket { create bind getattr setopt read write nlmsg_read nlmsg_write };
-# create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write
-#		allow $1 sysctl_net_t:dir { search getattr };
-#		allow $1 sysctl_net_t:file { read open getattr };
-#		allow $1 sysfs_t:file { read open getattr };
-#		allow $1 sysfs_t:lnk_file read;
-#		allow $1 system_dbusd_var_run_t:dir search;
-#
-#		allow $1 system_dbusd_var_run_t:sock_file write;
-
-#		allow $1 system_dbusd_t:unix_stream_socket connectto;
-#		allow $1 system_dbusd_t:dbus send_msg;
-
-#		allow $1 var_lib_t:dir { write add_name create read };
-#		allow $1 var_lib_t:file { getattr read write open };
-
-#		allow $1 var_run_t:dir { add_name write remove_name };
-#		allow $1 var_run_t:sock_file { create setattr unlink };
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -13,18 +13,15 @@
 #
 interface(`tailscale_network_connection',`
 		gen_require(`
-			type http_port_t, net_conf_t;
+			type http_port_t;
 			type kernel_t;
 			type tun_tap_device_t;
 
-			type init_t, init_var_run_t;
 			type node_t;
 		')
 		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
 		allow $1 chkpwd_t:process { noatsecure };
 
-		allow $1 init_t:dir search;
-		allow $1 init_t:file { read open getattr };
 		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
         allow $1 self:tcp_socket create_stream_socket_perms;
         allow $1 self:udp_socket create_socket_perms;
@@ -33,13 +30,10 @@ interface(`tailscale_network_connection',`
 		allow $1 self:unix_dgram_socket { create connect getattr write };
 		allow $1 http_port_t:tcp_socket name_connect;
 		allow $1 kernel_t:unix_dgram_socket sendto;
-		allow $1 net_conf_t:file { getattr read open };
-		allow $1 net_conf_t:lnk_file read;
 		allow $1 self:netlink_route_socket { create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write };
 		allow $1 self:netlink_generic_socket { read bind create getattr setopt write };
 		allow $1 self:rawip_socket { setopt create bind };
 		# allow $1 unreserved_port_t:tcp_socket name_bind;
 		allow $1 tun_tap_device_t:chr_file { all_chr_file_perms };
 		allow $1 self:tun_socket create;
-		allow $1 init_var_run_t:unix_dgram_socket { sendto write };
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -1,0 +1,100 @@
+## <summary>Policy for network configuration: tailscale server and client.</summary>
+#
+########################################
+## <summary>
+##      Perform network connections.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+## <rolecap/>
+#
+interface(`tailscale_network_connection',`
+		gen_require(`
+			type http_port_t, net_conf_t;
+			type proc_t, proc_net_t;
+			type sysctl_net_t;
+			type sysfs_t;
+			type system_dbusd_var_run_t, system_dbusd_t;
+			type var_lib_t;
+			type var_run_t;
+			type passwd_file_t;
+			class dbus { send_msg };
+			type NetworkManager_t;
+			type cert_t;
+			type kernel_t;
+			type tun_tap_device_t;
+			type kmod_exec_t;
+			type modules_dep_t, modules_conf_t, modules_object_t;
+			type init_t, init_var_run_t;
+			#type iptables_exec_t;
+			type node_t;
+			type sshd_key_t;
+			type devpts_t;
+		#	type local_login_t;
+#			type user_home_dir_t;
+		')
+#		allow $1 user_home_dir_t:dir getattr;
+# userdom_getattr_user_home_dirs(
+		# domtrans_pattern($1, login_exec_t, login_t);
+		allow $1 devpts_t:chr_file { open read write ioctl getattr setattr relabelfrom relabelto };
+		#allow $1 local_login_t:process { noatsecure rlimitinh };
+		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
+		allow $1 chkpwd_t:process { noatsecure };
+
+		allow $1 init_t:dir search;
+		allow $1 init_t:file { read open getattr };
+		#allow $1 iptables_exec_t:file { getattr execute };
+		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
+		allow $1 NetworkManager_t:dbus send_msg;
+		allow $1 cert_t:dir { search read open };
+		allow $1 cert_t:file { read open getattr };
+		allow $1 cert_t:lnk_file read;
+		allow $1 passwd_file_t:file { read open getattr };
+        allow $1 self:tcp_socket create_stream_socket_perms;
+        allow $1 self:udp_socket create_socket_perms;
+		allow $1 node_t:udp_socket node_bind;
+		allow $1 node_t:tcp_socket node_bind;
+		allow $1 self:unix_dgram_socket { create connect getattr write };
+		allow $1 http_port_t:tcp_socket name_connect;
+		allow $1 kernel_t:unix_dgram_socket sendto;
+		allow $1 net_conf_t:file { getattr read open };
+		allow $1 net_conf_t:lnk_file read;
+		allow $1 proc_net_t:lnk_file read;
+		allow $1 proc_net_t:file { read open getattr };
+		allow $1 proc_t:file { read open };
+		allow $1 proc_t:dir read;
+		allow $1 self:netlink_route_socket { create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write };
+		allow $1 self:netlink_generic_socket { read bind create getattr setopt write };
+		allow $1 self:rawip_socket { setopt create bind };
+		# allow $1 unreserved_port_t:tcp_socket name_bind;
+		allow $1 tun_tap_device_t:chr_file { all_chr_file_perms };
+		allow $1 self:tun_socket create;
+		allow $1 init_var_run_t:unix_dgram_socket { sendto write };
+		# allow $1 init_var_run_t:sock_file { all_sock_file_perms };
+		# allow $1 tun_tap_device_t:chr_file { read write open ioctl getattr create };
+		# dev_filetrans($1, tun_tap_device_t, chr_file, "tailscale0")
+		allow $1 kmod_exec_t:file { open read execute execute_no_trans map };
+		allow $1 modules_conf_t:dir { getattr read open search };
+		allow $1 modules_conf_t:file { getattr read open };
+		allow $1 modules_object_t:dir { search read open };
+		allow $1 modules_dep_t:file { read open getattr map };
+		# allow $1 self:netlink_route_socket { create bind getattr setopt read write nlmsg_read nlmsg_write };
+# create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write
+		allow $1 sysctl_net_t:dir { search getattr };
+		allow $1 sysctl_net_t:file { read open getattr };
+		allow $1 sysfs_t:file { read open getattr };
+		allow $1 sysfs_t:lnk_file read;
+		allow $1 system_dbusd_var_run_t:dir search;
+		allow $1 system_dbusd_var_run_t:sock_file write;
+		allow $1 system_dbusd_t:unix_stream_socket connectto;
+		allow $1 system_dbusd_t:dbus send_msg;
+		allow $1 var_lib_t:dir { write add_name create read };
+		allow $1 var_lib_t:file { getattr read write open };
+		allow $1 var_run_t:dir { add_name write remove_name };
+		allow $1 var_run_t:sock_file { create setattr unlink };
+		# Access key files
+        allow $1 sshd_key_t:file read_file_perms;
+')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -33,8 +33,9 @@ interface(`tailscale_network_connection',`
 #			type cert_t;
 			type kernel_t;
 			type tun_tap_device_t;
-			type kmod_exec_t;
-			type modules_dep_t, modules_conf_t, modules_object_t;
+#			type kmod_exec_t;
+
+#			type modules_dep_t, modules_conf_t, modules_object_t;
 			type init_t, init_var_run_t;
 			#type iptables_exec_t;
 			type node_t;
@@ -85,11 +86,13 @@ interface(`tailscale_network_connection',`
 		# allow $1 init_var_run_t:sock_file { all_sock_file_perms };
 		# allow $1 tun_tap_device_t:chr_file { read write open ioctl getattr create };
 		# dev_filetrans($1, tun_tap_device_t, chr_file, "tailscale0")
-		allow $1 kmod_exec_t:file { open read execute execute_no_trans map };
-		allow $1 modules_conf_t:dir { getattr read open search };
-		allow $1 modules_conf_t:file { getattr read open };
-		allow $1 modules_object_t:dir { search read open };
-		allow $1 modules_dep_t:file { read open getattr map };
+#		allow $1 kmod_exec_t:file { open read execute execute_no_trans map };
+
+#		allow $1 modules_conf_t:dir { getattr read open search };
+#		allow $1 modules_conf_t:file { getattr read open };
+#		allow $1 modules_object_t:dir { search read open };
+#		allow $1 modules_dep_t:file { read open getattr map };
+#
 		# allow $1 self:netlink_route_socket { create bind getattr setopt read write nlmsg_read nlmsg_write };
 # create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write
 #		allow $1 sysctl_net_t:dir { search getattr };

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -25,7 +25,7 @@ interface(`tailscale_network_connection',`
 #
 #			type var_lib_t;
 
-			type var_run_t;
+#			type var_run_t;
 
 			# type passwd_file_t;
 #			class dbus { send_msg };
@@ -106,8 +106,8 @@ interface(`tailscale_network_connection',`
 #		allow $1 var_lib_t:dir { write add_name create read };
 #		allow $1 var_lib_t:file { getattr read write open };
 
-		allow $1 var_run_t:dir { add_name write remove_name };
-		allow $1 var_run_t:sock_file { create setattr unlink };
+#		allow $1 var_run_t:dir { add_name write remove_name };
+#		allow $1 var_run_t:sock_file { create setattr unlink };
 		# Access key files
         allow $1 sshd_key_t:file read_file_perms;
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -20,7 +20,7 @@ interface(`tailscale_network_connection',`
 			type system_dbusd_var_run_t, system_dbusd_t;
 			type var_lib_t;
 			type var_run_t;
-			type passwd_file_t;
+			# type passwd_file_t;
 			class dbus { send_msg };
 			type NetworkManager_t;
 			type cert_t;
@@ -32,14 +32,16 @@ interface(`tailscale_network_connection',`
 			#type iptables_exec_t;
 			type node_t;
 			type sshd_key_t;
-			type devpts_t;
+			# type devpts_t;
 		#	type local_login_t;
 #			type user_home_dir_t;
 		')
 #		allow $1 user_home_dir_t:dir getattr;
 # userdom_getattr_user_home_dirs(
 		# domtrans_pattern($1, login_exec_t, login_t);
-		allow $1 devpts_t:chr_file { open read write ioctl getattr setattr relabelfrom relabelto };
+
+		# allow $1 devpts_t:chr_file { open read write ioctl getattr setattr relabelfrom relabelto };
+
 		#allow $1 local_login_t:process { noatsecure rlimitinh };
 		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
 		allow $1 chkpwd_t:process { noatsecure };
@@ -52,7 +54,7 @@ interface(`tailscale_network_connection',`
 		allow $1 cert_t:dir { search read open };
 		allow $1 cert_t:file { read open getattr };
 		allow $1 cert_t:lnk_file read;
-		allow $1 passwd_file_t:file { read open getattr };
+		# allow $1 passwd_file_t:file { read open getattr };
         allow $1 self:tcp_socket create_stream_socket_perms;
         allow $1 self:udp_socket create_socket_perms;
 		allow $1 node_t:udp_socket node_bind;

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -38,7 +38,7 @@ interface(`tailscale_network_connection',`
 			type init_t, init_var_run_t;
 			#type iptables_exec_t;
 			type node_t;
-			type sshd_key_t;
+#			type sshd_key_t;
 			# type devpts_t;
 		#	type local_login_t;
 #			type user_home_dir_t;
@@ -108,6 +108,4 @@ interface(`tailscale_network_connection',`
 
 #		allow $1 var_run_t:dir { add_name write remove_name };
 #		allow $1 var_run_t:sock_file { create setattr unlink };
-		# Access key files
-        allow $1 sshd_key_t:file read_file_perms;
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -15,15 +15,18 @@ interface(`tailscale_network_connection',`
 		gen_require(`
 			type http_port_t, net_conf_t;
 #			type proc_t;
-			type proc_net_t;
+#			type proc_net_t;
 #			type sysctl_net_t;
-			type sysfs_t;
-			type system_dbusd_var_run_t, system_dbusd_t;
+#			type sysfs_t;
+#
+#			type system_dbusd_var_run_t;
+
+#			type system_dbusd_t;
 			type var_lib_t;
 			type var_run_t;
 			# type passwd_file_t;
-			class dbus { send_msg };
-			type NetworkManager_t;
+#			class dbus { send_msg };
+#			type NetworkManager_t;
 #			type cert_t;
 			type kernel_t;
 			type tun_tap_device_t;
@@ -51,7 +54,7 @@ interface(`tailscale_network_connection',`
 		allow $1 init_t:file { read open getattr };
 		#allow $1 iptables_exec_t:file { getattr execute };
 		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
-		allow $1 NetworkManager_t:dbus send_msg;
+#		allow $1 NetworkManager_t:dbus send_msg;
 #		allow $1 cert_t:dir { search read open };
 #		allow $1 cert_t:file { read open getattr };
 #		allow $1 cert_t:lnk_file read;
@@ -65,8 +68,8 @@ interface(`tailscale_network_connection',`
 		allow $1 kernel_t:unix_dgram_socket sendto;
 		allow $1 net_conf_t:file { getattr read open };
 		allow $1 net_conf_t:lnk_file read;
-		allow $1 proc_net_t:lnk_file read;
-		allow $1 proc_net_t:file { read open getattr };
+#		allow $1 proc_net_t:lnk_file read;
+#		allow $1 proc_net_t:file { read open getattr };
 #		allow $1 proc_t:file { read open };
 #		allow $1 proc_t:dir read;
 		allow $1 self:netlink_route_socket { create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write };
@@ -88,12 +91,14 @@ interface(`tailscale_network_connection',`
 # create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write
 #		allow $1 sysctl_net_t:dir { search getattr };
 #		allow $1 sysctl_net_t:file { read open getattr };
-		allow $1 sysfs_t:file { read open getattr };
-		allow $1 sysfs_t:lnk_file read;
-		allow $1 system_dbusd_var_run_t:dir search;
-		allow $1 system_dbusd_var_run_t:sock_file write;
-		allow $1 system_dbusd_t:unix_stream_socket connectto;
-		allow $1 system_dbusd_t:dbus send_msg;
+#		allow $1 sysfs_t:file { read open getattr };
+#		allow $1 sysfs_t:lnk_file read;
+#		allow $1 system_dbusd_var_run_t:dir search;
+#
+#		allow $1 system_dbusd_var_run_t:sock_file write;
+
+#		allow $1 system_dbusd_t:unix_stream_socket connectto;
+#		allow $1 system_dbusd_t:dbus send_msg;
 		allow $1 var_lib_t:dir { write add_name create read };
 		allow $1 var_lib_t:file { getattr read write open };
 		allow $1 var_run_t:dir { add_name write remove_name };

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -12,21 +12,16 @@
 ## <rolecap/>
 #
 interface(`tailscale_network_connection',`
-		gen_require(`
-#			type http_port_t;
-			type kernel_t;
+		#gen_require(`
+		#	type kernel_t;
 
-		#	type node_t;
-		')
+		#')
 		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
 
 		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
 
-		allow $1 self:rawip_socket { setopt create bind };
+		#allow $1 self:rawip_socket { setopt create bind };
 
-		#allow $1 node_t:udp_socket node_bind;
-		#allow $1 node_t:tcp_socket node_bind;
-		#allow $1 http_port_t:tcp_socket name_connect;
-		allow $1 kernel_t:unix_dgram_socket sendto;
-		allow $1 chkpwd_t:process { noatsecure };
+		#allow $1 kernel_t:unix_dgram_socket sendto;
+		#allow $1 chkpwd_t:process { noatsecure };
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -13,10 +13,10 @@
 #
 interface(`tailscale_network_connection',`
 		gen_require(`
-			type http_port_t;
+#			type http_port_t;
 			type kernel_t;
 
-			type node_t;
+		#	type node_t;
 		')
 		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
 
@@ -24,9 +24,9 @@ interface(`tailscale_network_connection',`
 
 		allow $1 self:rawip_socket { setopt create bind };
 
-		allow $1 node_t:udp_socket node_bind;
-		allow $1 node_t:tcp_socket node_bind;
-		allow $1 http_port_t:tcp_socket name_connect;
+		#allow $1 node_t:udp_socket node_bind;
+		#allow $1 node_t:tcp_socket node_bind;
+		#allow $1 http_port_t:tcp_socket name_connect;
 		allow $1 kernel_t:unix_dgram_socket sendto;
 		allow $1 chkpwd_t:process { noatsecure };
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -18,7 +18,7 @@ interface(`tailscale_network_connection',`
 		#')
 		allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
 
-		allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
+		# allow $1 self:capability { net_admin dac_override dac_read_search net_raw sys_ptrace sys_tty_config setuid setgid chown };
 
 		#allow $1 self:rawip_socket { setopt create bind };
 

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -15,7 +15,6 @@ interface(`tailscale_network_connection',`
 		gen_require(`
 			type http_port_t;
 			type kernel_t;
-			type tun_tap_device_t;
 
 			type node_t;
 		')
@@ -33,7 +32,4 @@ interface(`tailscale_network_connection',`
 		allow $1 self:netlink_route_socket { create ioctl read getattr write setattr append bind connect getopt setopt shutdown nlmsg_read nlmsg_write };
 		allow $1 self:netlink_generic_socket { read bind create getattr setopt write };
 		allow $1 self:rawip_socket { setopt create bind };
-		# allow $1 unreserved_port_t:tcp_socket name_bind;
-		allow $1 tun_tap_device_t:chr_file { all_chr_file_perms };
-		allow $1 self:tun_socket create;
 ')

--- a/tailscaled.if
+++ b/tailscaled.if
@@ -22,8 +22,11 @@ interface(`tailscale_network_connection',`
 #			type system_dbusd_var_run_t;
 
 #			type system_dbusd_t;
-			type var_lib_t;
+#
+#			type var_lib_t;
+
 			type var_run_t;
+
 			# type passwd_file_t;
 #			class dbus { send_msg };
 #			type NetworkManager_t;
@@ -99,8 +102,10 @@ interface(`tailscale_network_connection',`
 
 #		allow $1 system_dbusd_t:unix_stream_socket connectto;
 #		allow $1 system_dbusd_t:dbus send_msg;
-		allow $1 var_lib_t:dir { write add_name create read };
-		allow $1 var_lib_t:file { getattr read write open };
+
+#		allow $1 var_lib_t:dir { write add_name create read };
+#		allow $1 var_lib_t:file { getattr read write open };
+
 		allow $1 var_run_t:dir { add_name write remove_name };
 		allow $1 var_run_t:sock_file { create setattr unlink };
 		# Access key files

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -1,15 +1,12 @@
 policy_module(tailscaled, 1.0.0)
 
-# NOTE:
-# What is going on with /var/lib/tailscaled
-
 # References,
 # https://wiki.gentoo.org/wiki/SELinux/Tutorials/Creating_a_daemon_domain
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux/writing-a-custom-selinux-policy_using-selinux
 # https://selinuxproject.org/page/ObjectClassesPerms
-#
-#
-#
+# https://danwalsh.livejournal.com/51435.html
+# https://fedoraproject.org/wiki/SELinux/Unsound_or_dangerous_SELinux_policy_practices
+
 gen_require(`
 	type devpts_t;
 	type sshd_key_t;
@@ -45,24 +42,44 @@ files_type(tailscale_var_run_t)
 # tailscaled local policy
 #
 
+# Section 1 - Stars here
+# Covers policy for interaction between tailscale binaries and its files
+
 # Allow tailscaled in tailscaled_t context to execute itself to run another instance
 # This is required when the child is execve'd with the parameter "be-child"
 allow tailscaled_t tailscaled_exec_t:file execute_no_trans;
 
-# Allow tailscaled in tailscaled_t context to execute /usr/bin/login which has a context of login_exec_t
-can_exec(tailscaled_t, login_exec_t)
-# Make tailscaled_t context an entry point for auth login programs like /usr/bin/login
-auth_login_entry_type(tailscaled_t)
-# Make tailscaled_t a domain that is used for a login program (/usr/bin/login) - defined in system/authlogin.if
-auth_login_pgm_domain(tailscaled_t)
+# Allow tailscaled_t to manage /var/lib/tailscale and the files in it which has a context of tailscale_var_lib_t
+manage_dirs_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
+manage_files_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
+# Allow tailscaled_t to manage /var/run/tailscale and the regular files, symlinks and socket files which has a context of tailscale_var_run_t
+manage_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
+manage_dirs_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
+manage_sock_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
+manage_lnk_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
 
-# Allow tailscaled_t to read /etc/passwd password file - defined in system/authlogin.if
-auth_read_passwd_file(tailscaled_t)
-# Allow tailscaled_t to read /etc/shadow password file - defined in system/authlogin.if
-auth_read_shadow(tailscaled_t)
+# Section 1 - Ends here
 
-# Access tailscaled_t to read ssh key files
-allow tailscaled_t sshd_key_t:file read_file_perms;
+# Section 2 - Starts here
+# Covers policy for capabilities given to tailscale
+
+allow tailscaled_t self:process { transition setexec setsched };
+# allow $1 self:process { setsched siginh noatsecure rlimitinh setexec transition };
+# Allow tailscaled_t to use net_admin capabilities. Required when the daemon starts
+allow tailscaled_t self:capability { net_admin };
+# Allow tailscaled_t to use sensitive DAC capabilities. Required when SSH is attempted
+allow tailscaled_t self:capability { dac_read_search dac_override };
+# Allow tailscaled_t to configure tty devices. Required when login is being setup after SSH
+allow tailscaled_t self:capability { sys_tty_config };
+# Allow tailscaled_t to setgid. Required when login is being setup after SSH
+allow tailscaled_t self:capability { setgid };
+# Allow tailscaled_t capabilities required when login is setup after SSH and before shell is spawned
+allow tailscaled_t self:capability { setuid chown fowner fsetid };
+
+# Section 2 - Ends here
+
+# Section 3 - Starts here
+# Covers policy for permissions given to tailscale to read, write and execute binaries
 
 # Allow tailscaled_t to execute iptables in the iptables domain - defined in system/iptables.if
 iptables_domtrans(tailscaled_t)
@@ -70,29 +87,12 @@ iptables_domtrans(tailscaled_t)
 # Allow tailscaled_t to execute ifconfig in the ifconfig domain - defined in system/sysnetwork.if
 sysnet_domtrans_ifconfig(tailscaled_t)
 
-# Allow tailscaled_t to get attributes of user home directories - defined in system/userdom.if
-userdom_getattr_user_home_dirs(tailscaled_t)
-# Allow tailscaled_t to search user home directories - defined in system/userdom.if
-userdom_search_user_home_dirs(tailscaled_t)
-
-# Allow tailscaled to send and receive TCP traffic on generic network interfaces
-# corenet_tcp_sendrecv_generic_if(tailscaled_t)
-tailscale_network_connection(tailscaled_t)
-# domain_can_mmap_files(tailscaled_t)
-# systemd_exec_notify(tailscaled_t)
-# systemd_notify_domtrans(tailscaled_t)
-#init_write_pid_socket(tailscaled_t)
-#init_dgram_send(tailscaled_t)
-#init_use_notify(tailscaled_t)
+# Allow tailscaled_t to list all the processes on the system - defined in support/misc_patterns.spt
+# Ref - https://danwalsh.livejournal.com/51435.html
 ps_process_pattern(tailscaled_t, domain)
-corecmd_exec_bin(tailscaled_t)
 
-# Allow tailscaled_t to read and write the pty multiplexor (/dev/ptmx) - defined in kernel/terminal.if
-term_use_ptmx(tailscaled_t)
-# Transform tailscaled_t into a pty type used by a login programs, like sshd - defined in kernel/terminal.if 
-term_login_pty(tailscaled_t)
-# Allow tailscaled_t to read and write to a generic pty type
-allow tailscaled_t devpts_t:chr_file { read write_chr_file_perms setattr relabel_chr_file_perms };
+# Allow tailscaled_t to execute generic programs in bin directory without a domain transition - defined in kernel/corecommands.if
+corecmd_exec_bin(tailscaled_t)
 
 # Allow tailscaled_t to read the network state information - defined in kernel/kernel.if
 kernel_read_network_state(tailscaled_t)
@@ -101,35 +101,22 @@ kernel_read_net_sysctls(tailscaled_t)
 # Allow tailscaled_t to read hardware state information from /sysfs - defined in kernel/devices.if
 dev_read_sysfs(tailscaled_t)
 
+# Allow tailscaled_t to read generic SSL certificates - defined in system/miscfiles.if
+miscfiles_read_generic_certs(tailscaled_t)
+
+# Section 3 - Ends here
+
+# Section 4 - Starts here
+# Covers policy for permissions given to tailscale to create sockets, read and write data to sockets
+
+# Allow tailscaled_t to read DBUS pid files - defined in contrib/dbus.if
+dbus_read_pid_files(tailscaled_t)
 # Allow tailscaled_t to send a message on the system DBUS - defined in contrib/dbus.if
 dbus_send_system_bus(tailscaled_t)
 # Allow tailscaled_t to connect to session bus types with a unix stream socket - defined in contrib/dbus.if
 dbus_stream_connect_system_dbusd(tailscaled_t)
-# Allow tailscaled_t to read DBUS pid files - defined in contrib/dbus.if
-dbus_read_pid_files(tailscaled_t)
 # Allow tailscaled_t to send and receive messages from NetworkManager over DBUS - defined in contrib/networkmanager.if
 networkmanager_dbus_chat(tailscaled_t)
-
-# Allow tailscaled_t to read generic SSL certificates - defined in system/miscfiles.if
-miscfiles_read_generic_certs(tailscaled_t)
-
-optional_policy(`
-	unconfined_shell_domtrans(tailscaled_t)
-')
-#auth_use_pam(tailscaled_t)
-#auth_domtrans_chk_passwd(tailscaled_t)
-#auth_signal_chk_passwd(tailscaled_t)
-#auth_rw_login_records(tailscaled_t)
-
-# Allow tailscaled_t to manage /var/lib/tailscale and the files in it which has a context of tailscale_var_lib_t
-manage_dirs_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
-manage_files_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
-
-# Allow tailscaled_t to manage /var/run/tailscale and the regular files, symlinks and socket files which has a context of tailscale_var_run_t
-manage_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
-manage_dirs_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
-manage_sock_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
-manage_lnk_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
 
 # Allow tailscaled_t to search the contents of kernel module directories
 files_search_kernel_modules(tailscaled_t)
@@ -146,17 +133,6 @@ kernel_request_load_module(tailscaled_t)
 allow tailscaled_t self:tun_socket create;
 # Allow tailscaled_t to read and write to TUN/TAP virtual network device - defined in kernel/corenetwork.if
 corenet_rw_tun_tap_dev(tailscaled_t)
-
-# Allow tailscaled_t to use net_admin capabilities. Required when the daemon starts
-allow tailscaled_t self:capability { net_admin };
-# Allow tailscaled_t to use sensitive DAC capabilities. Required when SSH is attempted
-allow tailscaled_t self:capability { dac_read_search };
-# Allow tailscaled_t to configure tty devices. Required when login is being setup after SSH
-allow tailscaled_t self:capability { sys_tty_config };
-# Allow tailscaled_t to setgid. Required when login is being setup after SSH
-allow tailscaled_t self:capability { setgid };
-# Allow tailscaled_t to setuid. Required when login is setup after SSH and before shell is spawned
-allow tailscaled_t self:capability { setuid };
 
 # Allow tailscaled_t to create sockets to use for the netlink families - generic and route
 # These rules are part of wireguard as well. Ref - wireguard.te
@@ -177,3 +153,44 @@ corenet_tcp_connect_http_port(tailscaled_t)
 
 # Allow tailscaled_t to send messages to Send messages to kernel unix datagram sockets - defined in kernel/kernel.if
 kernel_dgram_send(tailscaled_t)
+
+# Section 4 - Ends here
+
+# Section 5 - Starts here
+# Covers policy for login over SSH to succeed
+
+# Allow tailscaled in tailscaled_t context to execute /usr/bin/login which has a context of login_exec_t
+can_exec(tailscaled_t, login_exec_t)
+# Make tailscaled_t context an entry point for auth login programs like /usr/bin/login
+auth_login_entry_type(tailscaled_t)
+# Make tailscaled_t a domain that is used for a login program (/usr/bin/login) - defined in system/authlogin.if
+auth_login_pgm_domain(tailscaled_t)
+
+# Allow tailscaled_t to get attributes of user home directories - defined in system/userdom.if
+userdom_getattr_user_home_dirs(tailscaled_t)
+# Allow tailscaled_t to search user home directories - defined in system/userdom.if
+userdom_search_user_home_dirs(tailscaled_t)
+
+# Allow tailscaled_t to read /etc/passwd password file - defined in system/authlogin.if
+auth_read_passwd_file(tailscaled_t)
+# Allow tailscaled_t to read /etc/shadow password file - defined in system/authlogin.if
+auth_read_shadow(tailscaled_t)
+
+# Access tailscaled_t to read ssh key files
+allow tailscaled_t sshd_key_t:file read_file_perms;
+
+# Allow tailscaled_t to read and write the pty multiplexor (/dev/ptmx) - defined in kernel/terminal.if
+term_use_ptmx(tailscaled_t)
+# Transform tailscaled_t into a pty type used by a login programs, like sshd - defined in kernel/terminal.if 
+term_login_pty(tailscaled_t)
+# Allow tailscaled_t to read and write to a generic pty type
+allow tailscaled_t devpts_t:chr_file { read write_chr_file_perms setattr relabel_chr_file_perms };
+
+# Allow tailscaled_t to transition to the unconfined domain by executing a shell - defined in roles/unconfineduser.if
+# This is required when the user to login over SSH is unconfined (which is a typical case for most distributions)
+# Used in ssh.te, remotelogin.te, etc.
+optional_policy(`
+	unconfined_shell_domtrans(tailscaled_t)
+')
+
+# Section 5 - Ends here

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -12,14 +12,6 @@ policy_module(tailscaled, 1.0.0)
 gen_require(`
 	type devpts_t;
 	type sshd_key_t;
-    # type system_dbusd_t, root_t, bin_t, var_t, tmp_t, unconfined_t, initrc_t, fs_t, cgroup_t, var_lib_nfs_t, http_port_t, shell_exec_t, syslogd_t, setroubleshootd_t;
-    # These are temporarily defined to allow access to OAS Manager.
-    # Identify a more generic allow policy to get uid for running process.
-    # type chkpwd_t, crond_t, locate_t, logrotate_t, prelink_cron_system_t, prelink_t, readahead_t, sysstat_t, system_cronjob_t, semanage_t, setfiles_t, sshd_t;
-    # type postfix_pickup_t, udev_t, user_tmp_t;
-    # type rhsmcertd_t, systemd_tmpfiles_t, systemd_logind_t;
-    # type rpm_var_lib_t;
-    # role unconfined_r;
 ')
 
 ########################################
@@ -149,11 +141,4 @@ modutils_read_module_config(tailscaled_t)
 modutils_domtrans_kmod(tailscaled_t)
 # Allow tailscaled_t to request the kernel to load a module (tun) - defined in kernel/kernel.if
 kernel_request_load_module(tailscaled_t)
-
-# type=AVC msg=audit(1674306452.044:92911): avc:  denied  { setsched } for  pid=139224 comm="login" scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:system_r:tailscaled_t:s0 tclass=process permissive=0
-# type=AVC msg=audit(1674306452.044:92912): avc:  denied  { getattr } for  pid=139224 comm="login" path="/dev/pts/5" dev="devpts" ino=8 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=chr_file permissive=0
-# type=AVC msg=audit(1674306452.044:92913): avc:  denied  { write } for  pid=139224 comm="login" name="log" dev="devtmpfs" ino=36531 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devlog_t:s0 tclass=sock_file permissive=0
-
-#auth_domtrans_login_program(tailscaled_t, login_exec_t)
-# domtrans_pattern(tailscaled_t, login_exec_t, login_t)
 

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -6,6 +6,7 @@ policy_module(tailscaled, 1.0.0)
 # References,
 # https://wiki.gentoo.org/wiki/SELinux/Tutorials/Creating_a_daemon_domain
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux/writing-a-custom-selinux-policy_using-selinux
+# https://selinuxproject.org/page/ObjectClassesPerms
 #
 #
 #
@@ -83,7 +84,6 @@ tailscale_network_connection(tailscaled_t)
 #init_write_pid_socket(tailscaled_t)
 #init_dgram_send(tailscaled_t)
 #init_use_notify(tailscaled_t)
-corenet_tcp_bind_generic_port(tailscaled_t)
 ps_process_pattern(tailscaled_t, domain)
 corecmd_exec_bin(tailscaled_t)
 
@@ -147,7 +147,16 @@ allow tailscaled_t self:tun_socket create;
 # Allow tailscaled_t to read and write to TUN/TAP virtual network device - defined in kernel/corenetwork.if
 corenet_rw_tun_tap_dev(tailscaled_t)
 
-
+# Allow tailscaled_t to use net_admin capabilities. Required when the daemon starts
+allow tailscaled_t self:capability { net_admin };
+# Allow tailscaled_t to use sensitive DAC capabilities. Required when SSH is attempted
+allow tailscaled_t self:capability { dac_read_search };
+# Allow tailscaled_t to configure tty devices. Required when login is being setup after SSH
+allow tailscaled_t self:capability { sys_tty_config };
+# Allow tailscaled_t to setgid. Required when login is being setup after SSH
+allow tailscaled_t self:capability { setgid };
+# Allow tailscaled_t to setuid. Required when login is setup after SSH and before shell is spawned
+allow tailscaled_t self:capability { setuid };
 
 # Allow tailscaled_t to create sockets to use for the netlink families - generic and route
 # These rules are part of wireguard as well. Ref - wireguard.te
@@ -159,6 +168,9 @@ allow tailscaled_t self:tcp_socket create_stream_socket_perms;
 allow tailscaled_t self:udp_socket create_socket_perms;
 allow tailscaled_t self:unix_dgram_socket create_socket_perms;
 allow tailscaled_t self:rawip_socket create_socket_perms;
+
+# Allow tailscaled_t to bind to generic TCP ports - defined in kernel/corenetwork.if
+corenet_tcp_bind_generic_port(tailscaled_t)
 
 # Allow tailscaled_t to make outgoing http connections - defined in kernel/corenetwork.if
 corenet_tcp_connect_http_port(tailscaled_t)

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -90,6 +90,11 @@ term_login_pty(tailscaled_t)
 # Allow tailscaled_t to read and write to a generic pty type
 allow tailscaled_t devpts_t:chr_file { read write_chr_file_perms setattr relabel_chr_file_perms };
 
+# Allow tailscaled_t to read network sysctls - defined in kernel/kernel.if
+kernel_read_net_sysctls(tailscaled_t)
+
+# Allow tailscaled_t to read generic SSL certificates - defined in system/miscfiles.if
+miscfiles_read_generic_certs(tailscaled_t)
 
 optional_policy(`
 	unconfined_shell_domtrans(tailscaled_t)

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -142,3 +142,7 @@ modutils_domtrans_kmod(tailscaled_t)
 # Allow tailscaled_t to request the kernel to load a module (tun) - defined in kernel/kernel.if
 kernel_request_load_module(tailscaled_t)
 
+# Allow tailscaled_t to create tun socket
+allow tailscaled_t self:tun_socket create;
+# Allow tailscaled_t to read and write to TUN/TAP virtual network device - defined in kernel/corenetwork.if
+corenet_rw_tun_tap_dev(tailscaled_t)

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -90,8 +90,21 @@ term_login_pty(tailscaled_t)
 # Allow tailscaled_t to read and write to a generic pty type
 allow tailscaled_t devpts_t:chr_file { read write_chr_file_perms setattr relabel_chr_file_perms };
 
+# Allow tailscaled_t to read the network state information - defined in kernel/kernel.if
+kernel_read_network_state(tailscaled_t)
 # Allow tailscaled_t to read network sysctls - defined in kernel/kernel.if
 kernel_read_net_sysctls(tailscaled_t)
+# Allow tailscaled_t to read hardware state information from /sysfs - defined in kernel/devices.if
+dev_read_sysfs(tailscaled_t)
+
+# Allow tailscaled_t to send a message on the system DBUS - defined in contrib/dbus.if
+dbus_send_system_bus(tailscaled_t)
+# Allow tailscaled_t to connect to session bus types with a unix stream socket - defined in contrib/dbus.if
+dbus_stream_connect_system_dbusd(tailscaled_t)
+# Allow tailscaled_t to read DBUS pid files - defined in contrib/dbus.if
+dbus_read_pid_files(tailscaled_t)
+# Allow tailscaled_t to send and receive messages from NetworkManager over DBUS - defined in contrib/networkmanager.if
+networkmanager_dbus_chat(tailscaled_t)
 
 # Allow tailscaled_t to read generic SSL certificates - defined in system/miscfiles.if
 miscfiles_read_generic_certs(tailscaled_t)

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -1,5 +1,14 @@
-policy_module(tailscaled, 0.0.1)
+policy_module(tailscaled, 1.0.0)
 
+# NOTE:
+# What is going on with /var/lib/tailscaled
+
+# References,
+# https://wiki.gentoo.org/wiki/SELinux/Tutorials/Creating_a_daemon_domain
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux/writing-a-custom-selinux-policy_using-selinux
+#
+#
+#
 #gen_require(`
     # type system_dbusd_t, root_t, bin_t, var_t, tmp_t, unconfined_t, initrc_t, fs_t, cgroup_t, var_lib_nfs_t, http_port_t, shell_exec_t, syslogd_t, setroubleshootd_t;
     # These are temporarily defined to allow access to OAS Manager.
@@ -18,22 +27,29 @@ policy_module(tailscaled, 0.0.1)
 
 type tailscaled_t;
 type tailscaled_exec_t;
-# Create a domain for a service started by init - defined in system/init.if
+# Create a domain for tailscaled service started by init - defined in system/init.if
 init_daemon_domain(tailscaled_t, tailscaled_exec_t)
-#domain_entry_file(tailscaled_t, tailscaled_exec_t)
-domain_entry_file_spec_domtrans(tailscaled_t, tailscaled_exec_t)
-# locallogin_domtrans(tailscaled_t)
-# remotelogin_domtrans(tailscaled_t)
+# Make the type tailscaled_exec_t usable as an entry point for the domain tailscaled_exec_t - defined in kernel/domain.if
+domain_entry_file(tailscaled_t, tailscaled_exec_t)
+# Why was the following added?
+# domain_entry_file_spec_domtrans(tailscaled_t, tailscaled_exec_t)
 
+# Type for systemd unit file type
 type tailscaled_unit_file_t;
-# Use this type for systemd unit file type
-# Automatically defines access for systemd files
+# Creates the file type used for Tailscale systemd unit files - defined in system/systemd.if
 systemd_unit_file(tailscaled_unit_file_t)
 
-type tailscale_t;
-type tailscale_exec_t;
-# Create a domain for application - defined in policy/modules/system/application.if
-application_domain(tailscale_t, tailscale_exec_t)
+########################################
+#
+# tailscaled local policy
+#
+
+# Allow tailscaled in tailscaled_t context to execute itself to run another instance
+# This is required when the child is execve'd with the parameter "be-child"
+allow tailscaled_t tailscaled_exec_t:file execute_no_trans;
+
+# Allow tailscaled in tailscaled_t context to execute /usr/bin/login which has a context of login_exec_t
+can_exec(tailscaled_t, login_exec_t)
 
 # Allow tailscaled to send and receive TCP traffic on generic network interfaces
 # corenet_tcp_sendrecv_generic_if(tailscaled_t)
@@ -48,13 +64,13 @@ iptables_domtrans(tailscaled_t)
 sysnet_domtrans_ifconfig(tailscaled_t)
 corenet_tcp_bind_generic_port(tailscaled_t)
 ps_process_pattern(tailscaled_t, domain)
-# auth_login_entry_type(tailscaled_t)
 corecmd_exec_bin(tailscaled_t)
 term_use_ptmx(tailscaled_t)
 term_login_pty(tailscaled_t)
 userdom_getattr_user_home_dirs(tailscaled_t)
 userdom_search_user_home_dirs(tailscaled_t)
 
+auth_login_entry_type(tailscaled_t)
 auth_login_pgm_domain(tailscaled_t)
 auth_read_shadow(tailscaled_t)
 optional_policy(`

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -159,4 +159,6 @@ allow tailscaled_t self:tcp_socket create_stream_socket_perms;
 allow tailscaled_t self:udp_socket create_socket_perms;
 allow tailscaled_t self:unix_dgram_socket create_socket_perms;
 
+# Allow tailscaled_t to make outgoing http connections - defined in kernel/corenetwork.if
+corenet_tcp_connect_http_port(tailscaled_t)
 

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -146,3 +146,17 @@ kernel_request_load_module(tailscaled_t)
 allow tailscaled_t self:tun_socket create;
 # Allow tailscaled_t to read and write to TUN/TAP virtual network device - defined in kernel/corenetwork.if
 corenet_rw_tun_tap_dev(tailscaled_t)
+
+
+
+# Allow tailscaled_t to create sockets to use for the netlink families - generic and route
+# These rules are part of wireguard as well. Ref - wireguard.te
+allow tailscaled_t self:netlink_generic_socket create_socket_perms;
+allow tailscaled_t self:netlink_route_socket create_netlink_socket_perms;
+
+# Allow tailscale daemon to create different types of sockets
+allow tailscaled_t self:tcp_socket create_stream_socket_perms;
+allow tailscaled_t self:udp_socket create_socket_perms;
+allow tailscaled_t self:unix_dgram_socket create_socket_perms;
+
+

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -38,6 +38,10 @@ type tailscaled_unit_file_t;
 # Creates the file type used for Tailscale systemd unit files - defined in system/systemd.if
 systemd_unit_file(tailscaled_unit_file_t)
 
+# Type for /var/lib/tailscale directory file type
+type tailscale_var_lib_t;
+files_type(tailscale_var_lib_t)
+
 ########################################
 #
 # tailscaled local policy
@@ -117,7 +121,9 @@ optional_policy(`
 #auth_signal_chk_passwd(tailscaled_t)
 #auth_rw_login_records(tailscaled_t)
 
-
+# Allow tailscaled_t to manage the directory /var/lib/tailscale and the files in it which has a context of tailscale_var_lib_t
+manage_dirs_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
+manage_files_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
 
 # type=AVC msg=audit(1674306452.044:92911): avc:  denied  { setsched } for  pid=139224 comm="login" scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:system_r:tailscaled_t:s0 tclass=process permissive=0
 # type=AVC msg=audit(1674306452.044:92912): avc:  denied  { getattr } for  pid=139224 comm="login" path="/dev/pts/5" dev="devpts" ino=8 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=chr_file permissive=0

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -189,7 +189,7 @@ term_login_pty(tailscaled_t)
 allow tailscaled_t devpts_t:chr_file { read write_chr_file_perms setattr relabel_chr_file_perms };
 
 # Allow tailscaled_t to transition to the unconfined domain by executing a shell - defined in roles/unconfineduser.if
-# This is required when the user to login over SSH is unconfined (which is a typical case for most distributions)
+# This is required when the user that logs in over SSH, is unconfined (which is a typical use case in most cases)
 # Used in ssh.te, remotelogin.te, etc.
 optional_policy(`
 	unconfined_shell_domtrans(tailscaled_t)

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -2,8 +2,10 @@ policy_module(tailscaled, 1.0.0)
 
 # References,
 # https://wiki.gentoo.org/wiki/SELinux/Tutorials/Creating_a_daemon_domain
+# https://wiki.gentoo.org/wiki/SELinux/Tutorials/How_does_a_process_get_into_a_certain_context
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux/writing-a-custom-selinux-policy_using-selinux
 # https://selinuxproject.org/page/ObjectClassesPerms
+# https://selinuxproject.org/page/NB_Domain_and_Object_Transitions
 # https://danwalsh.livejournal.com/51435.html
 # https://fedoraproject.org/wiki/SELinux/Unsound_or_dangerous_SELinux_policy_practices
 

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -158,7 +158,10 @@ allow tailscaled_t self:netlink_route_socket create_netlink_socket_perms;
 allow tailscaled_t self:tcp_socket create_stream_socket_perms;
 allow tailscaled_t self:udp_socket create_socket_perms;
 allow tailscaled_t self:unix_dgram_socket create_socket_perms;
+allow tailscaled_t self:rawip_socket create_socket_perms;
 
 # Allow tailscaled_t to make outgoing http connections - defined in kernel/corenetwork.if
 corenet_tcp_connect_http_port(tailscaled_t)
 
+# Allow tailscaled_t to send messages to Send messages to kernel unix datagram sockets - defined in kernel/kernel.if
+kernel_dgram_send(tailscaled_t)

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -42,6 +42,10 @@ systemd_unit_file(tailscaled_unit_file_t)
 type tailscale_var_lib_t;
 files_type(tailscale_var_lib_t)
 
+# Type for /var/run/tailscale directory file type
+type tailscale_var_run_t;
+files_type(tailscale_var_run_t)
+
 ########################################
 #
 # tailscaled local policy
@@ -121,9 +125,15 @@ optional_policy(`
 #auth_signal_chk_passwd(tailscaled_t)
 #auth_rw_login_records(tailscaled_t)
 
-# Allow tailscaled_t to manage the directory /var/lib/tailscale and the files in it which has a context of tailscale_var_lib_t
+# Allow tailscaled_t to manage /var/lib/tailscale and the files in it which has a context of tailscale_var_lib_t
 manage_dirs_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
 manage_files_pattern(tailscaled_t, tailscale_var_lib_t, tailscale_var_lib_t)
+
+# Allow tailscaled_t to manage /var/run/tailscale and the regular files, symlinks and socket files which has a context of tailscale_var_run_t
+manage_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
+manage_dirs_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
+manage_sock_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
+manage_lnk_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
 
 # type=AVC msg=audit(1674306452.044:92911): avc:  denied  { setsched } for  pid=139224 comm="login" scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:system_r:tailscaled_t:s0 tclass=process permissive=0
 # type=AVC msg=audit(1674306452.044:92912): avc:  denied  { getattr } for  pid=139224 comm="login" path="/dev/pts/5" dev="devpts" ino=8 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=chr_file permissive=0

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -9,7 +9,8 @@ policy_module(tailscaled, 1.0.0)
 #
 #
 #
-#gen_require(`
+gen_require(`
+	type devpts_t;
     # type system_dbusd_t, root_t, bin_t, var_t, tmp_t, unconfined_t, initrc_t, fs_t, cgroup_t, var_lib_nfs_t, http_port_t, shell_exec_t, syslogd_t, setroubleshootd_t;
     # These are temporarily defined to allow access to OAS Manager.
     # Identify a more generic allow policy to get uid for running process.
@@ -18,7 +19,7 @@ policy_module(tailscaled, 1.0.0)
     # type rhsmcertd_t, systemd_tmpfiles_t, systemd_logind_t;
     # type rpm_var_lib_t;
     # role unconfined_r;
-#')
+')
 
 ########################################
 #
@@ -31,8 +32,6 @@ type tailscaled_exec_t;
 init_daemon_domain(tailscaled_t, tailscaled_exec_t)
 # Make the type tailscaled_exec_t usable as an entry point for the domain tailscaled_exec_t - defined in kernel/domain.if
 domain_entry_file(tailscaled_t, tailscaled_exec_t)
-# Why was the following added?
-# domain_entry_file_spec_domtrans(tailscaled_t, tailscaled_exec_t)
 
 # Type for systemd unit file type
 type tailscaled_unit_file_t;
@@ -50,6 +49,26 @@ allow tailscaled_t tailscaled_exec_t:file execute_no_trans;
 
 # Allow tailscaled in tailscaled_t context to execute /usr/bin/login which has a context of login_exec_t
 can_exec(tailscaled_t, login_exec_t)
+# Make tailscaled_t context an entry point for auth login programs like /usr/bin/login
+auth_login_entry_type(tailscaled_t)
+# Make tailscaled_t a domain that is used for a login program (/usr/bin/login) - defined in system/authlogin.if
+auth_login_pgm_domain(tailscaled_t)
+
+# Allow tailscaled_t to read /etc/passwd password file - defined in system/authlogin.if
+auth_read_passwd_file(tailscaled_t)
+# Allow tailscaled_t to read /etc/shadow password file - defined in system/authlogin.if
+auth_read_shadow(tailscaled_t)
+
+# Allow tailscaled_t to execute iptables in the iptables domain - defined in system/iptables.if
+iptables_domtrans(tailscaled_t)
+
+# Allow tailscaled_t to execute ifconfig in the ifconfig domain - defined in system/sysnetwork.if
+sysnet_domtrans_ifconfig(tailscaled_t)
+
+# Allow tailscaled_t to get attributes of user home directories - defined in system/userdom.if
+userdom_getattr_user_home_dirs(tailscaled_t)
+# Allow tailscaled_t to search user home directories - defined in system/userdom.if
+userdom_search_user_home_dirs(tailscaled_t)
 
 # Allow tailscaled to send and receive TCP traffic on generic network interfaces
 # corenet_tcp_sendrecv_generic_if(tailscaled_t)
@@ -60,19 +79,18 @@ tailscale_network_connection(tailscaled_t)
 #init_write_pid_socket(tailscaled_t)
 #init_dgram_send(tailscaled_t)
 #init_use_notify(tailscaled_t)
-iptables_domtrans(tailscaled_t)
-sysnet_domtrans_ifconfig(tailscaled_t)
 corenet_tcp_bind_generic_port(tailscaled_t)
 ps_process_pattern(tailscaled_t, domain)
 corecmd_exec_bin(tailscaled_t)
-term_use_ptmx(tailscaled_t)
-term_login_pty(tailscaled_t)
-userdom_getattr_user_home_dirs(tailscaled_t)
-userdom_search_user_home_dirs(tailscaled_t)
 
-auth_login_entry_type(tailscaled_t)
-auth_login_pgm_domain(tailscaled_t)
-auth_read_shadow(tailscaled_t)
+# Allow tailscaled_t to read and write the pty multiplexor (/dev/ptmx) - defined in kernel/terminal.if
+term_use_ptmx(tailscaled_t)
+# Transform tailscaled_t into a pty type used by a login programs, like sshd - defined in kernel/terminal.if 
+term_login_pty(tailscaled_t)
+# Allow tailscaled_t to read and write to a generic pty type
+allow tailscaled_t devpts_t:chr_file { read write_chr_file_perms setattr relabel_chr_file_perms };
+
+
 optional_policy(`
 	unconfined_shell_domtrans(tailscaled_t)
 ')

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -1,0 +1,76 @@
+policy_module(tailscaled, 0.0.1)
+
+#gen_require(`
+    # type system_dbusd_t, root_t, bin_t, var_t, tmp_t, unconfined_t, initrc_t, fs_t, cgroup_t, var_lib_nfs_t, http_port_t, shell_exec_t, syslogd_t, setroubleshootd_t;
+    # These are temporarily defined to allow access to OAS Manager.
+    # Identify a more generic allow policy to get uid for running process.
+    # type chkpwd_t, crond_t, locate_t, logrotate_t, prelink_cron_system_t, prelink_t, readahead_t, sysstat_t, system_cronjob_t, semanage_t, setfiles_t, sshd_t;
+    # type postfix_pickup_t, udev_t, user_tmp_t;
+    # type rhsmcertd_t, systemd_tmpfiles_t, systemd_logind_t;
+    # type rpm_var_lib_t;
+    # role unconfined_r;
+#')
+
+########################################
+#
+# Declarations
+#
+
+type tailscaled_t;
+type tailscaled_exec_t;
+# Create a domain for a service started by init - defined in system/init.if
+init_daemon_domain(tailscaled_t, tailscaled_exec_t)
+#domain_entry_file(tailscaled_t, tailscaled_exec_t)
+domain_entry_file_spec_domtrans(tailscaled_t, tailscaled_exec_t)
+# locallogin_domtrans(tailscaled_t)
+# remotelogin_domtrans(tailscaled_t)
+
+type tailscaled_unit_file_t;
+# Use this type for systemd unit file type
+# Automatically defines access for systemd files
+systemd_unit_file(tailscaled_unit_file_t)
+
+type tailscale_t;
+type tailscale_exec_t;
+# Create a domain for application - defined in policy/modules/system/application.if
+application_domain(tailscale_t, tailscale_exec_t)
+
+# Allow tailscaled to send and receive TCP traffic on generic network interfaces
+# corenet_tcp_sendrecv_generic_if(tailscaled_t)
+tailscale_network_connection(tailscaled_t)
+# domain_can_mmap_files(tailscaled_t)
+# systemd_exec_notify(tailscaled_t)
+# systemd_notify_domtrans(tailscaled_t)
+#init_write_pid_socket(tailscaled_t)
+#init_dgram_send(tailscaled_t)
+#init_use_notify(tailscaled_t)
+iptables_domtrans(tailscaled_t)
+sysnet_domtrans_ifconfig(tailscaled_t)
+corenet_tcp_bind_generic_port(tailscaled_t)
+ps_process_pattern(tailscaled_t, domain)
+# auth_login_entry_type(tailscaled_t)
+corecmd_exec_bin(tailscaled_t)
+term_use_ptmx(tailscaled_t)
+term_login_pty(tailscaled_t)
+userdom_getattr_user_home_dirs(tailscaled_t)
+userdom_search_user_home_dirs(tailscaled_t)
+
+auth_login_pgm_domain(tailscaled_t)
+auth_read_shadow(tailscaled_t)
+optional_policy(`
+	unconfined_shell_domtrans(tailscaled_t)
+')
+#auth_use_pam(tailscaled_t)
+#auth_domtrans_chk_passwd(tailscaled_t)
+#auth_signal_chk_passwd(tailscaled_t)
+#auth_rw_login_records(tailscaled_t)
+
+
+
+# type=AVC msg=audit(1674306452.044:92911): avc:  denied  { setsched } for  pid=139224 comm="login" scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:system_r:tailscaled_t:s0 tclass=process permissive=0
+# type=AVC msg=audit(1674306452.044:92912): avc:  denied  { getattr } for  pid=139224 comm="login" path="/dev/pts/5" dev="devpts" ino=8 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=chr_file permissive=0
+# type=AVC msg=audit(1674306452.044:92913): avc:  denied  { write } for  pid=139224 comm="login" name="log" dev="devtmpfs" ino=36531 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devlog_t:s0 tclass=sock_file permissive=0
+
+#auth_domtrans_login_program(tailscaled_t, login_exec_t)
+# domtrans_pattern(tailscaled_t, login_exec_t, login_t)
+

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -139,6 +139,17 @@ manage_dirs_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
 manage_sock_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
 manage_lnk_files_pattern(tailscaled_t, tailscale_var_run_t, tailscale_var_run_t)
 
+# Allow tailscaled_t to search the contents of kernel module directories
+files_search_kernel_modules(tailscaled_t)
+# Allow tailscaled_t to read dependencies of kernel modules - defined in system/modutils.if
+modutils_read_module_deps_files(tailscaled_t)
+# Allow tailscaled_t to read the configuration options used when loading modules - defined in system/modutils.if
+modutils_read_module_config(tailscaled_t)
+# Allow tailscaled_t to execute insmod in the kmod domain to load a module (tun) - defined in system/modutils.if
+modutils_domtrans_kmod(tailscaled_t)
+# Allow tailscaled_t to request the kernel to load a module (tun) - defined in kernel/kernel.if
+kernel_request_load_module(tailscaled_t)
+
 # type=AVC msg=audit(1674306452.044:92911): avc:  denied  { setsched } for  pid=139224 comm="login" scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:system_r:tailscaled_t:s0 tclass=process permissive=0
 # type=AVC msg=audit(1674306452.044:92912): avc:  denied  { getattr } for  pid=139224 comm="login" path="/dev/pts/5" dev="devpts" ino=8 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devpts_t:s0 tclass=chr_file permissive=0
 # type=AVC msg=audit(1674306452.044:92913): avc:  denied  { write } for  pid=139224 comm="login" name="log" dev="devtmpfs" ino=36531 scontext=system_u:system_r:tailscaled_t:s0 tcontext=system_u:object_r:devlog_t:s0 tclass=sock_file permissive=0

--- a/tailscaled.te
+++ b/tailscaled.te
@@ -11,6 +11,7 @@ policy_module(tailscaled, 1.0.0)
 #
 gen_require(`
 	type devpts_t;
+	type sshd_key_t;
     # type system_dbusd_t, root_t, bin_t, var_t, tmp_t, unconfined_t, initrc_t, fs_t, cgroup_t, var_lib_nfs_t, http_port_t, shell_exec_t, syslogd_t, setroubleshootd_t;
     # These are temporarily defined to allow access to OAS Manager.
     # Identify a more generic allow policy to get uid for running process.
@@ -66,6 +67,9 @@ auth_login_pgm_domain(tailscaled_t)
 auth_read_passwd_file(tailscaled_t)
 # Allow tailscaled_t to read /etc/shadow password file - defined in system/authlogin.if
 auth_read_shadow(tailscaled_t)
+
+# Access tailscaled_t to read ssh key files
+allow tailscaled_t sshd_key_t:file read_file_perms;
 
 # Allow tailscaled_t to execute iptables in the iptables domain - defined in system/iptables.if
 iptables_domtrans(tailscaled_t)


### PR DESCRIPTION
First version contains the following,
- Adds the context "tailscaled_t" for Tailscale service and runs it confined
- Support for Tailscale SSH on systems where SELinux is running in enforced mode

To support Tailscale SSH and fix [ssh: handle SELinux somehow?](tailscale/tailscale#4908), it does the following,
- Adds support to execute login binary when  SSH is done
- Adds support to transition to users that are part of unconfined domain

Tested on Fedora 37  